### PR TITLE
Update DataGridView on tag deletion and remove unnecessary refreshing

### DIFF
--- a/BooruDatasetTagManager/Form1.cs
+++ b/BooruDatasetTagManager/Form1.cs
@@ -527,6 +527,7 @@ namespace BooruDatasetTagManager
             if (dataGridView2.SelectedCells.Count > 0)
             {
                 string delTag = (string)dataGridView2.SelectedCells[0].Value;
+                dataGridView2.Rows.RemoveAt(dataGridView2.CurrentCell.RowIndex);
                 Program.DataManager.DeleteTagFromAll(delTag);
                 Program.DataManager.UpdateData();
                 int index = -1;
@@ -541,7 +542,6 @@ namespace BooruDatasetTagManager
                 if (index != -1)
                     dataGridView1.Rows.RemoveAt(index);
             }
-            BindTagList();
         }
 
         private void translateTagsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
UI's current behaviour will refresh the All Tags DGV upon 'Delete from All' being clicked.

This is inconvenient for datasets with a long list of tags, as it necessitates scrolling back down to where the user left off for each removed tag.

PR aims to fix this issue by updating the DGV instead of refreshing it.