### PR TITLE
Add the python image interrogator code (only)

### DIFF
--- a/interrogator_rpc/interrogator.py
+++ b/interrogator_rpc/interrogator.py
@@ -29,21 +29,27 @@ BLIP2_CAPTIONING_NAMES = [
 ]
 
 WD_TAGGER_NAMES = [
-    "wd-v1-4-vit-tagger",
     "wd-v1-4-convnext-tagger",
-    "wd-v1-4-vit-tagger-v2",
     "wd-v1-4-convnext-tagger-v2",
-    "wd-v1-4-swinv2-tagger-v2",
+    "wd-v1-4-convnextv2-tagger-v2",
     "wd-v1-4-moat-tagger-v2",
+    "wd-v1-4-swinv2-tagger-v2",
+    "wd-v1-4-vit-tagger",
+    "wd-v1-4-vit-tagger-v2",
 ]
+
 WD_TAGGER_THRESHOLDS = [
     0.35,
     0.35,
-    0.3537,
-    0.3685,
-    0.3771,
-    0.3771,
+    0.35,
+    0.35,
+    0.35,
+    0.35,
+    0.35,
 ]  # v1: idk if it's okay  v2: P=R thresholds on each repo https://huggingface.co/SmilingWolf
+
+
+
 
 INTERROGATORS = (
     [captioning.BLIP()]
@@ -55,7 +61,8 @@ INTERROGATORS = (
         for i, name in enumerate(WD_TAGGER_NAMES)
     ]
 )
-INTERROGATOR_NAMES = [it.name() for it in INTERROGATORS]
+
+INTERROGATOR_NAMES = [it.name() if it else "deep-danbooru + waifu-diffusion" for it in INTERROGATORS]
 
 INTERROGATOR_MAP = dict(zip(INTERROGATOR_NAMES, INTERROGATORS))
 

--- a/interrogator_rpc/interrogator.py
+++ b/interrogator_rpc/interrogator.py
@@ -62,7 +62,7 @@ INTERROGATORS = (
     ]
 )
 
-INTERROGATOR_NAMES = [it.name() if it else "deep-danbooru + waifu-diffusion" for it in INTERROGATORS]
+INTERROGATOR_NAMES = [it.name() for it in INTERROGATORS]
 
 INTERROGATOR_MAP = dict(zip(INTERROGATOR_NAMES, INTERROGATORS))
 

--- a/interrogator_rpc/rpc_proto/services.proto
+++ b/interrogator_rpc/rpc_proto/services.proto
@@ -1,30 +1,41 @@
 
 syntax = "proto3";
 
+
+option csharp_namespace = "Image_Interrogator_Ns";
+
+
+package interrogator;
+
 message InterrogatorListing {
     repeated string interrogator_names = 1;
 }
 
-message InterrogationRequest{
+message NetworkInterrogationParameters {
+
     string interrogator_network   = 1;
     float  interrogator_threshold = 2;
-    bytes  interrogate_image      = 3;
+}
+
+message InterrogationRequest {
+    repeated NetworkInterrogationParameters params = 1;
+    bytes interrogate_image                        = 2;
 }
 
 
 message TagEntry {
-    string  tag         = 1;
+    string tag        = 1;
     float probability = 2;
 }
 
 message ImageTagResults {
     repeated TagEntry tags = 1;
-    bool interrogate_ok   = 2;
-    string error_msg      = 3;
+    bool interrogate_ok    = 2;
+    string error_msg       = 3;
 }
 
 
-// RPC actiona CANNOT have empty requests, or empty responses.
+// RPC actions CANNOT have empty requests, or empty responses.
 // This.... is stupid.
 message InterrogatorListingRequest {
 

--- a/interrogator_rpc/rpc_proto/services_pb2.py
+++ b/interrogator_rpc/rpc_proto/services_pb2.py
@@ -13,23 +13,26 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eservices.proto\"1\n\x13InterrogatorListing\x12\x1a\n\x12interrogator_names\x18\x01 \x03(\t\"o\n\x14InterrogationRequest\x12\x1c\n\x14interrogator_network\x18\x01 \x01(\t\x12\x1e\n\x16interrogator_threshold\x18\x02 \x01(\x02\x12\x19\n\x11interrogate_image\x18\x03 \x01(\x0c\",\n\x08TagEntry\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x13\n\x0bprobability\x18\x02 \x01(\x02\"U\n\x0fImageTagResults\x12\x17\n\x04tags\x18\x01 \x03(\x0b\x32\t.TagEntry\x12\x16\n\x0einterrogate_ok\x18\x02 \x01(\x08\x12\x11\n\terror_msg\x18\x03 \x01(\t\"\x1c\n\x1aInterrogatorListingRequest2\x98\x01\n\x11ImageInterrogator\x12\x46\n\x11ListInterrogators\x12\x1b.InterrogatorListingRequest\x1a\x14.InterrogatorListing\x12;\n\x10InterrogateImage\x12\x15.InterrogationRequest\x1a\x10.ImageTagResultsb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eservices.proto\x12\x0cinterrogator\"1\n\x13InterrogatorListing\x12\x1a\n\x12interrogator_names\x18\x01 \x03(\t\"^\n\x1eNetworkInterrogationParameters\x12\x1c\n\x14interrogator_network\x18\x01 \x01(\t\x12\x1e\n\x16interrogator_threshold\x18\x02 \x01(\x02\"o\n\x14InterrogationRequest\x12<\n\x06params\x18\x01 \x03(\x0b\x32,.interrogator.NetworkInterrogationParameters\x12\x19\n\x11interrogate_image\x18\x02 \x01(\x0c\",\n\x08TagEntry\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x13\n\x0bprobability\x18\x02 \x01(\x02\"b\n\x0fImageTagResults\x12$\n\x04tags\x18\x01 \x03(\x0b\x32\x16.interrogator.TagEntry\x12\x16\n\x0einterrogate_ok\x18\x02 \x01(\x08\x12\x11\n\terror_msg\x18\x03 \x01(\t\"\x1c\n\x1aInterrogatorListingRequest2\xcc\x01\n\x11ImageInterrogator\x12`\n\x11ListInterrogators\x12(.interrogator.InterrogatorListingRequest\x1a!.interrogator.InterrogatorListing\x12U\n\x10InterrogateImage\x12\".interrogator.InterrogationRequest\x1a\x1d.interrogator.ImageTagResultsB\x18\xaa\x02\x15Image_Interrogator_Nsb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'services_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
-  _globals['_INTERROGATORLISTING']._serialized_start=18
-  _globals['_INTERROGATORLISTING']._serialized_end=67
-  _globals['_INTERROGATIONREQUEST']._serialized_start=69
-  _globals['_INTERROGATIONREQUEST']._serialized_end=180
-  _globals['_TAGENTRY']._serialized_start=182
-  _globals['_TAGENTRY']._serialized_end=226
-  _globals['_IMAGETAGRESULTS']._serialized_start=228
-  _globals['_IMAGETAGRESULTS']._serialized_end=313
-  _globals['_INTERROGATORLISTINGREQUEST']._serialized_start=315
-  _globals['_INTERROGATORLISTINGREQUEST']._serialized_end=343
-  _globals['_IMAGEINTERROGATOR']._serialized_start=346
-  _globals['_IMAGEINTERROGATOR']._serialized_end=498
+  DESCRIPTOR._serialized_options = b'\252\002\025Image_Interrogator_Ns'
+  _globals['_INTERROGATORLISTING']._serialized_start=32
+  _globals['_INTERROGATORLISTING']._serialized_end=81
+  _globals['_NETWORKINTERROGATIONPARAMETERS']._serialized_start=83
+  _globals['_NETWORKINTERROGATIONPARAMETERS']._serialized_end=177
+  _globals['_INTERROGATIONREQUEST']._serialized_start=179
+  _globals['_INTERROGATIONREQUEST']._serialized_end=290
+  _globals['_TAGENTRY']._serialized_start=292
+  _globals['_TAGENTRY']._serialized_end=336
+  _globals['_IMAGETAGRESULTS']._serialized_start=338
+  _globals['_IMAGETAGRESULTS']._serialized_end=436
+  _globals['_INTERROGATORLISTINGREQUEST']._serialized_start=438
+  _globals['_INTERROGATORLISTINGREQUEST']._serialized_end=466
+  _globals['_IMAGEINTERROGATOR']._serialized_start=469
+  _globals['_IMAGEINTERROGATOR']._serialized_end=673
 # @@protoc_insertion_point(module_scope)

--- a/interrogator_rpc/rpc_proto/services_pb2.pyi
+++ b/interrogator_rpc/rpc_proto/services_pb2.pyi
@@ -11,15 +11,21 @@ class InterrogatorListing(_message.Message):
     interrogator_names: _containers.RepeatedScalarFieldContainer[str]
     def __init__(self, interrogator_names: _Optional[_Iterable[str]] = ...) -> None: ...
 
-class InterrogationRequest(_message.Message):
-    __slots__ = ["interrogator_network", "interrogator_threshold", "interrogate_image"]
+class NetworkInterrogationParameters(_message.Message):
+    __slots__ = ["interrogator_network", "interrogator_threshold"]
     INTERROGATOR_NETWORK_FIELD_NUMBER: _ClassVar[int]
     INTERROGATOR_THRESHOLD_FIELD_NUMBER: _ClassVar[int]
-    INTERROGATE_IMAGE_FIELD_NUMBER: _ClassVar[int]
     interrogator_network: str
     interrogator_threshold: float
+    def __init__(self, interrogator_network: _Optional[str] = ..., interrogator_threshold: _Optional[float] = ...) -> None: ...
+
+class InterrogationRequest(_message.Message):
+    __slots__ = ["params", "interrogate_image"]
+    PARAMS_FIELD_NUMBER: _ClassVar[int]
+    INTERROGATE_IMAGE_FIELD_NUMBER: _ClassVar[int]
+    params: _containers.RepeatedCompositeFieldContainer[NetworkInterrogationParameters]
     interrogate_image: bytes
-    def __init__(self, interrogator_network: _Optional[str] = ..., interrogator_threshold: _Optional[float] = ..., interrogate_image: _Optional[bytes] = ...) -> None: ...
+    def __init__(self, params: _Optional[_Iterable[_Union[NetworkInterrogationParameters, _Mapping]]] = ..., interrogate_image: _Optional[bytes] = ...) -> None: ...
 
 class TagEntry(_message.Message):
     __slots__ = ["tag", "probability"]

--- a/interrogator_rpc/rpc_proto/services_pb2_grpc.py
+++ b/interrogator_rpc/rpc_proto/services_pb2_grpc.py
@@ -15,12 +15,12 @@ class ImageInterrogatorStub(object):
             channel: A grpc.Channel.
         """
         self.ListInterrogators = channel.unary_unary(
-                '/ImageInterrogator/ListInterrogators',
+                '/interrogator.ImageInterrogator/ListInterrogators',
                 request_serializer=services__pb2.InterrogatorListingRequest.SerializeToString,
                 response_deserializer=services__pb2.InterrogatorListing.FromString,
                 )
         self.InterrogateImage = channel.unary_unary(
-                '/ImageInterrogator/InterrogateImage',
+                '/interrogator.ImageInterrogator/InterrogateImage',
                 request_serializer=services__pb2.InterrogationRequest.SerializeToString,
                 response_deserializer=services__pb2.ImageTagResults.FromString,
                 )
@@ -56,7 +56,7 @@ def add_ImageInterrogatorServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'ImageInterrogator', rpc_method_handlers)
+            'interrogator.ImageInterrogator', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -75,7 +75,7 @@ class ImageInterrogator(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ImageInterrogator/ListInterrogators',
+        return grpc.experimental.unary_unary(request, target, '/interrogator.ImageInterrogator/ListInterrogators',
             services__pb2.InterrogatorListingRequest.SerializeToString,
             services__pb2.InterrogatorListing.FromString,
             options, channel_credentials,
@@ -92,7 +92,7 @@ class ImageInterrogator(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ImageInterrogator/InterrogateImage',
+        return grpc.experimental.unary_unary(request, target, '/interrogator.ImageInterrogator/InterrogateImage',
             services__pb2.InterrogationRequest.SerializeToString,
             services__pb2.ImageTagResults.FromString,
             options, channel_credentials,

--- a/interrogator_rpc/update_rpc.bat
+++ b/interrogator_rpc/update_rpc.bat
@@ -1,0 +1,5 @@
+
+
+
+
+python -m grpc_tools.protoc -I./rpc_proto/ --python_out=rpc_proto/ --pyi_out=rpc_proto/ --grpc_python_out=rpc_proto/ rpc_proto/services.proto


### PR DESCRIPTION
Ok, here is a PR of just the python interrogator codebase from my other branch. 

I have added the change where now you can specify a set of interrogators to use. 

This still has the "makes internet requests" on use issue.  I'm not entirely sure why that request isn't cached (it caches the actual network, but not the labels?). In any event, that can be fixed separately.

