### PR TITLE
Return interrogator results separately to the gRPC API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Interrogator binaries
+/interrogator_rpc/build
+/interrogator_rpc/dist

--- a/interrogator_rpc/create_dist_binary.bat
+++ b/interrogator_rpc/create_dist_binary.bat
@@ -1,0 +1,4 @@
+
+del /Q dist
+
+pyinstaller main.spec --noconfirm

--- a/interrogator_rpc/create_dist_binary.bat
+++ b/interrogator_rpc/create_dist_binary.bat
@@ -1,4 +1,5 @@
 
 del /Q dist
 
+rem pyinstaller --clean main.spec --noconfirm
 pyinstaller main.spec --noconfirm

--- a/interrogator_rpc/ext_kohya/cmd_args.py
+++ b/interrogator_rpc/ext_kohya/cmd_args.py
@@ -1,16 +1,21 @@
 import argparse
 
-parser = argparse.ArgumentParser()
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--device-id", type=int, help="CUDA Device ID to use interrogators", default=None
+    )
+    parser.add_argument(
+        "--force-install-torch",
+        choices=['cu117', 'cu118', 'cu120', 'cpu'],
+        help="Force install the latest PyTorch with specified compute platform (if not installed in this computer)",
+        default=None,
+    )
+
+    opts = parser.parse_args()
+
+    return opts
 
 
-parser.add_argument(
-    "--device-id", type=int, help="CUDA Device ID to use interrogators", default=None
-)
-parser.add_argument(
-    "--force-install-torch",
-    choices=['cu117', 'cu118', 'cu120', 'cpu'],
-    help="Force install the latest PyTorch with specified compute platform (if not installed in this computer)",
-    default=None,
-)
 
-opts = parser.parse_args()

--- a/interrogator_rpc/ext_kohya/devices.py
+++ b/interrogator_rpc/ext_kohya/devices.py
@@ -29,15 +29,17 @@ def has_mps():
 
 
 def get_cuda():
-    if cmd_args.opts.device_id is not None:
-        return torch.cuda.device(f"cuda:{cmd_args.opts.device_id}")
+    opts = cmd_args.get_args()
+    if opts.device_id is not None:
+        return torch.cuda.device(f"cuda:{opts.device_id}")
     else:
         return torch.cuda.device("cuda")
 
 
 def get_cuda_device():
-    if cmd_args.opts.device_id is not None:
-        return torch.device(f"cuda:{cmd_args.opts.device_id}")
+    opts = cmd_args.get_args()
+    if opts.device_id is not None:
+        return torch.device(f"cuda:{opts.device_id}")
     else:
         return torch.device("cuda")
 
@@ -66,5 +68,13 @@ def torch_gc():
             torch.cuda.ipc_collect()
 
 
-device = get_optimal_device()
-cpu = torch.device("cpu")
+device = None
+cpu = None
+
+
+def init_interrogator():
+    global device
+    global cpu
+
+    device = get_optimal_device()
+    cpu = torch.device("cpu")

--- a/interrogator_rpc/ext_kohya/launch.py
+++ b/interrogator_rpc/ext_kohya/launch.py
@@ -67,16 +67,18 @@ stderr: {result.stderr.decode(encoding="utf8", errors="ignore") if len(result.st
 
 
 def prepare_environment():
-    if cmd_args.opts.force_install_torch is None:
+    opts = cmd_args.get_args()
+
+    if opts.force_install_torch is None:
         pass
-    elif cmd_args.opts.force_install_torch == "cpu":
+    elif opts.force_install_torch == "cpu":
         torch_command = "pip install -U torch torchvision"
     else:
-        torch_command = f"pip install -U torch torchvision --index-url https://download.pytorch.org/whl/{cmd_args.opts.force_install_torch}"
+        torch_command = f"pip install -U torch torchvision --index-url https://download.pytorch.org/whl/{opts.force_install_torch}"
     if (
         not is_installed("torch")
         or not is_installed("torchvision")
-        or cmd_args.opts.force_install_torch is not None
+        or opts.force_install_torch is not None
     ):
         run(f'"{python}" -m {torch_command}')
     check_python_version()

--- a/interrogator_rpc/interrogator.py
+++ b/interrogator_rpc/interrogator.py
@@ -14,6 +14,7 @@ from ext_kohya import (
     tagger,
     captioning,
     paths,
+    devices,
 )
 
 paths.initialize()
@@ -66,9 +67,9 @@ INTERROGATOR_NAMES = [it.name() for it in INTERROGATORS]
 
 INTERROGATOR_MAP = dict(zip(INTERROGATOR_NAMES, INTERROGATORS))
 
-class ImageInterrogator:
-	def __init__(self):
-		pass
+
+def init():
+    devices.init_interrogator()
 
 
 

--- a/interrogator_rpc/main.py
+++ b/interrogator_rpc/main.py
@@ -199,8 +199,9 @@ def serve():
 
 
 if __name__ == "__main__":
-	logging.basicConfig(level = 1)
+	logging.basicConfig(level = logging.INFO)
 
+	interrogator.init()
 	print(rpc_proto.services_pb2.InterrogatorListing)
 
 	serve()

--- a/interrogator_rpc/main.spec
+++ b/interrogator_rpc/main.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'torch',
+        'tqdm',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        'matplotlib',
+        'h5py',
+    ],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='main',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='interrogator_rpc',
+)

--- a/interrogator_rpc/main.spec
+++ b/interrogator_rpc/main.spec
@@ -1,14 +1,34 @@
 # -*- mode: python ; coding: utf-8 -*-
-
+from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import collect_data_files
 
 a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[
+        *copy_metadata('tqdm'),
+        *copy_metadata('tensorflow'),
+        *copy_metadata('torch'),
+        *copy_metadata('regex'),
+        *copy_metadata('requests'),
+        *copy_metadata('packaging'),
+        *copy_metadata('pillow'),
+        *copy_metadata('filelock'),
+        *copy_metadata('onnxruntime_gpu'),
+        *copy_metadata('numpy'),
+        *copy_metadata('tokenizers'),
+        *copy_metadata('importlib_metadata'),
+
+        *collect_data_files('transformers', include_py_files=True, includes=['**/*.py']),
+    ],
     hiddenimports=[
         'torch',
+        'tensorflow',
         'tqdm',
+        'onnxruntime',
+        'onnxruntime_gpu',
+        'PIL',
     ],
     hookspath=[],
     hooksconfig={},

--- a/interrogator_rpc/rpc_proto/services.proto
+++ b/interrogator_rpc/rpc_proto/services.proto
@@ -12,14 +12,15 @@ message InterrogatorListing {
 }
 
 message NetworkInterrogationParameters {
-
     string interrogator_network   = 1;
     float  interrogator_threshold = 2;
 }
 
 message InterrogationRequest {
-    repeated NetworkInterrogationParameters params = 1;
-    bytes interrogate_image                        = 2;
+    repeated NetworkInterrogationParameters params                 = 1;
+    bytes                                   interrogate_image      = 2;
+    bool                                    skip_internet_requests = 3;
+    bool                                    serialize_vram_usage   = 4;
 }
 
 

--- a/interrogator_rpc/rpc_proto/services.proto
+++ b/interrogator_rpc/rpc_proto/services.proto
@@ -29,10 +29,17 @@ message TagEntry {
     float probability = 2;
 }
 
+message InterrogationResponse {
+    string network_name    = 1;
+    repeated TagEntry tags = 2;
+}
+
+
+
 message ImageTagResults {
-    repeated TagEntry tags = 1;
-    bool interrogate_ok    = 2;
-    string error_msg       = 3;
+    repeated InterrogationResponse responses = 1;
+    bool interrogate_ok                      = 2;
+    string error_msg                         = 3;
 }
 
 

--- a/interrogator_rpc/rpc_proto/services_pb2.py
+++ b/interrogator_rpc/rpc_proto/services_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eservices.proto\x12\x0cinterrogator\"1\n\x13InterrogatorListing\x12\x1a\n\x12interrogator_names\x18\x01 \x03(\t\"^\n\x1eNetworkInterrogationParameters\x12\x1c\n\x14interrogator_network\x18\x01 \x01(\t\x12\x1e\n\x16interrogator_threshold\x18\x02 \x01(\x02\"\xad\x01\n\x14InterrogationRequest\x12<\n\x06params\x18\x01 \x03(\x0b\x32,.interrogator.NetworkInterrogationParameters\x12\x19\n\x11interrogate_image\x18\x02 \x01(\x0c\x12\x1e\n\x16skip_internet_requests\x18\x03 \x01(\x08\x12\x1c\n\x14serialize_vram_usage\x18\x04 \x01(\x08\",\n\x08TagEntry\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x13\n\x0bprobability\x18\x02 \x01(\x02\"b\n\x0fImageTagResults\x12$\n\x04tags\x18\x01 \x03(\x0b\x32\x16.interrogator.TagEntry\x12\x16\n\x0einterrogate_ok\x18\x02 \x01(\x08\x12\x11\n\terror_msg\x18\x03 \x01(\t\"\x1c\n\x1aInterrogatorListingRequest2\xcc\x01\n\x11ImageInterrogator\x12`\n\x11ListInterrogators\x12(.interrogator.InterrogatorListingRequest\x1a!.interrogator.InterrogatorListing\x12U\n\x10InterrogateImage\x12\".interrogator.InterrogationRequest\x1a\x1d.interrogator.ImageTagResultsB\x18\xaa\x02\x15Image_Interrogator_Nsb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eservices.proto\x12\x0cinterrogator\"1\n\x13InterrogatorListing\x12\x1a\n\x12interrogator_names\x18\x01 \x03(\t\"^\n\x1eNetworkInterrogationParameters\x12\x1c\n\x14interrogator_network\x18\x01 \x01(\t\x12\x1e\n\x16interrogator_threshold\x18\x02 \x01(\x02\"\xad\x01\n\x14InterrogationRequest\x12<\n\x06params\x18\x01 \x03(\x0b\x32,.interrogator.NetworkInterrogationParameters\x12\x19\n\x11interrogate_image\x18\x02 \x01(\x0c\x12\x1e\n\x16skip_internet_requests\x18\x03 \x01(\x08\x12\x1c\n\x14serialize_vram_usage\x18\x04 \x01(\x08\",\n\x08TagEntry\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x13\n\x0bprobability\x18\x02 \x01(\x02\"S\n\x15InterrogationResponse\x12\x14\n\x0cnetwork_name\x18\x01 \x01(\t\x12$\n\x04tags\x18\x02 \x03(\x0b\x32\x16.interrogator.TagEntry\"t\n\x0fImageTagResults\x12\x36\n\tresponses\x18\x01 \x03(\x0b\x32#.interrogator.InterrogationResponse\x12\x16\n\x0einterrogate_ok\x18\x02 \x01(\x08\x12\x11\n\terror_msg\x18\x03 \x01(\t\"\x1c\n\x1aInterrogatorListingRequest2\xcc\x01\n\x11ImageInterrogator\x12`\n\x11ListInterrogators\x12(.interrogator.InterrogatorListingRequest\x1a!.interrogator.InterrogatorListing\x12U\n\x10InterrogateImage\x12\".interrogator.InterrogationRequest\x1a\x1d.interrogator.ImageTagResultsB\x18\xaa\x02\x15Image_Interrogator_Nsb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -29,10 +29,12 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_INTERROGATIONREQUEST']._serialized_end=353
   _globals['_TAGENTRY']._serialized_start=355
   _globals['_TAGENTRY']._serialized_end=399
-  _globals['_IMAGETAGRESULTS']._serialized_start=401
-  _globals['_IMAGETAGRESULTS']._serialized_end=499
-  _globals['_INTERROGATORLISTINGREQUEST']._serialized_start=501
-  _globals['_INTERROGATORLISTINGREQUEST']._serialized_end=529
-  _globals['_IMAGEINTERROGATOR']._serialized_start=532
-  _globals['_IMAGEINTERROGATOR']._serialized_end=736
+  _globals['_INTERROGATIONRESPONSE']._serialized_start=401
+  _globals['_INTERROGATIONRESPONSE']._serialized_end=484
+  _globals['_IMAGETAGRESULTS']._serialized_start=486
+  _globals['_IMAGETAGRESULTS']._serialized_end=602
+  _globals['_INTERROGATORLISTINGREQUEST']._serialized_start=604
+  _globals['_INTERROGATORLISTINGREQUEST']._serialized_end=632
+  _globals['_IMAGEINTERROGATOR']._serialized_start=635
+  _globals['_IMAGEINTERROGATOR']._serialized_end=839
 # @@protoc_insertion_point(module_scope)

--- a/interrogator_rpc/rpc_proto/services_pb2.py
+++ b/interrogator_rpc/rpc_proto/services_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eservices.proto\x12\x0cinterrogator\"1\n\x13InterrogatorListing\x12\x1a\n\x12interrogator_names\x18\x01 \x03(\t\"^\n\x1eNetworkInterrogationParameters\x12\x1c\n\x14interrogator_network\x18\x01 \x01(\t\x12\x1e\n\x16interrogator_threshold\x18\x02 \x01(\x02\"o\n\x14InterrogationRequest\x12<\n\x06params\x18\x01 \x03(\x0b\x32,.interrogator.NetworkInterrogationParameters\x12\x19\n\x11interrogate_image\x18\x02 \x01(\x0c\",\n\x08TagEntry\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x13\n\x0bprobability\x18\x02 \x01(\x02\"b\n\x0fImageTagResults\x12$\n\x04tags\x18\x01 \x03(\x0b\x32\x16.interrogator.TagEntry\x12\x16\n\x0einterrogate_ok\x18\x02 \x01(\x08\x12\x11\n\terror_msg\x18\x03 \x01(\t\"\x1c\n\x1aInterrogatorListingRequest2\xcc\x01\n\x11ImageInterrogator\x12`\n\x11ListInterrogators\x12(.interrogator.InterrogatorListingRequest\x1a!.interrogator.InterrogatorListing\x12U\n\x10InterrogateImage\x12\".interrogator.InterrogationRequest\x1a\x1d.interrogator.ImageTagResultsB\x18\xaa\x02\x15Image_Interrogator_Nsb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eservices.proto\x12\x0cinterrogator\"1\n\x13InterrogatorListing\x12\x1a\n\x12interrogator_names\x18\x01 \x03(\t\"^\n\x1eNetworkInterrogationParameters\x12\x1c\n\x14interrogator_network\x18\x01 \x01(\t\x12\x1e\n\x16interrogator_threshold\x18\x02 \x01(\x02\"\xad\x01\n\x14InterrogationRequest\x12<\n\x06params\x18\x01 \x03(\x0b\x32,.interrogator.NetworkInterrogationParameters\x12\x19\n\x11interrogate_image\x18\x02 \x01(\x0c\x12\x1e\n\x16skip_internet_requests\x18\x03 \x01(\x08\x12\x1c\n\x14serialize_vram_usage\x18\x04 \x01(\x08\",\n\x08TagEntry\x12\x0b\n\x03tag\x18\x01 \x01(\t\x12\x13\n\x0bprobability\x18\x02 \x01(\x02\"b\n\x0fImageTagResults\x12$\n\x04tags\x18\x01 \x03(\x0b\x32\x16.interrogator.TagEntry\x12\x16\n\x0einterrogate_ok\x18\x02 \x01(\x08\x12\x11\n\terror_msg\x18\x03 \x01(\t\"\x1c\n\x1aInterrogatorListingRequest2\xcc\x01\n\x11ImageInterrogator\x12`\n\x11ListInterrogators\x12(.interrogator.InterrogatorListingRequest\x1a!.interrogator.InterrogatorListing\x12U\n\x10InterrogateImage\x12\".interrogator.InterrogationRequest\x1a\x1d.interrogator.ImageTagResultsB\x18\xaa\x02\x15Image_Interrogator_Nsb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -25,14 +25,14 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_INTERROGATORLISTING']._serialized_end=81
   _globals['_NETWORKINTERROGATIONPARAMETERS']._serialized_start=83
   _globals['_NETWORKINTERROGATIONPARAMETERS']._serialized_end=177
-  _globals['_INTERROGATIONREQUEST']._serialized_start=179
-  _globals['_INTERROGATIONREQUEST']._serialized_end=290
-  _globals['_TAGENTRY']._serialized_start=292
-  _globals['_TAGENTRY']._serialized_end=336
-  _globals['_IMAGETAGRESULTS']._serialized_start=338
-  _globals['_IMAGETAGRESULTS']._serialized_end=436
-  _globals['_INTERROGATORLISTINGREQUEST']._serialized_start=438
-  _globals['_INTERROGATORLISTINGREQUEST']._serialized_end=466
-  _globals['_IMAGEINTERROGATOR']._serialized_start=469
-  _globals['_IMAGEINTERROGATOR']._serialized_end=673
+  _globals['_INTERROGATIONREQUEST']._serialized_start=180
+  _globals['_INTERROGATIONREQUEST']._serialized_end=353
+  _globals['_TAGENTRY']._serialized_start=355
+  _globals['_TAGENTRY']._serialized_end=399
+  _globals['_IMAGETAGRESULTS']._serialized_start=401
+  _globals['_IMAGETAGRESULTS']._serialized_end=499
+  _globals['_INTERROGATORLISTINGREQUEST']._serialized_start=501
+  _globals['_INTERROGATORLISTINGREQUEST']._serialized_end=529
+  _globals['_IMAGEINTERROGATOR']._serialized_start=532
+  _globals['_IMAGEINTERROGATOR']._serialized_end=736
 # @@protoc_insertion_point(module_scope)

--- a/interrogator_rpc/rpc_proto/services_pb2.pyi
+++ b/interrogator_rpc/rpc_proto/services_pb2.pyi
@@ -39,15 +39,23 @@ class TagEntry(_message.Message):
     probability: float
     def __init__(self, tag: _Optional[str] = ..., probability: _Optional[float] = ...) -> None: ...
 
-class ImageTagResults(_message.Message):
-    __slots__ = ["tags", "interrogate_ok", "error_msg"]
+class InterrogationResponse(_message.Message):
+    __slots__ = ["network_name", "tags"]
+    NETWORK_NAME_FIELD_NUMBER: _ClassVar[int]
     TAGS_FIELD_NUMBER: _ClassVar[int]
+    network_name: str
+    tags: _containers.RepeatedCompositeFieldContainer[TagEntry]
+    def __init__(self, network_name: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[TagEntry, _Mapping]]] = ...) -> None: ...
+
+class ImageTagResults(_message.Message):
+    __slots__ = ["responses", "interrogate_ok", "error_msg"]
+    RESPONSES_FIELD_NUMBER: _ClassVar[int]
     INTERROGATE_OK_FIELD_NUMBER: _ClassVar[int]
     ERROR_MSG_FIELD_NUMBER: _ClassVar[int]
-    tags: _containers.RepeatedCompositeFieldContainer[TagEntry]
+    responses: _containers.RepeatedCompositeFieldContainer[InterrogationResponse]
     interrogate_ok: bool
     error_msg: str
-    def __init__(self, tags: _Optional[_Iterable[_Union[TagEntry, _Mapping]]] = ..., interrogate_ok: bool = ..., error_msg: _Optional[str] = ...) -> None: ...
+    def __init__(self, responses: _Optional[_Iterable[_Union[InterrogationResponse, _Mapping]]] = ..., interrogate_ok: bool = ..., error_msg: _Optional[str] = ...) -> None: ...
 
 class InterrogatorListingRequest(_message.Message):
     __slots__ = []

--- a/interrogator_rpc/rpc_proto/services_pb2.pyi
+++ b/interrogator_rpc/rpc_proto/services_pb2.pyi
@@ -20,12 +20,16 @@ class NetworkInterrogationParameters(_message.Message):
     def __init__(self, interrogator_network: _Optional[str] = ..., interrogator_threshold: _Optional[float] = ...) -> None: ...
 
 class InterrogationRequest(_message.Message):
-    __slots__ = ["params", "interrogate_image"]
+    __slots__ = ["params", "interrogate_image", "skip_internet_requests", "serialize_vram_usage"]
     PARAMS_FIELD_NUMBER: _ClassVar[int]
     INTERROGATE_IMAGE_FIELD_NUMBER: _ClassVar[int]
+    SKIP_INTERNET_REQUESTS_FIELD_NUMBER: _ClassVar[int]
+    SERIALIZE_VRAM_USAGE_FIELD_NUMBER: _ClassVar[int]
     params: _containers.RepeatedCompositeFieldContainer[NetworkInterrogationParameters]
     interrogate_image: bytes
-    def __init__(self, params: _Optional[_Iterable[_Union[NetworkInterrogationParameters, _Mapping]]] = ..., interrogate_image: _Optional[bytes] = ...) -> None: ...
+    skip_internet_requests: bool
+    serialize_vram_usage: bool
+    def __init__(self, params: _Optional[_Iterable[_Union[NetworkInterrogationParameters, _Mapping]]] = ..., interrogate_image: _Optional[bytes] = ..., skip_internet_requests: bool = ..., serialize_vram_usage: bool = ...) -> None: ...
 
 class TagEntry(_message.Message):
     __slots__ = ["tag", "probability"]

--- a/interrogator_rpc/test.py
+++ b/interrogator_rpc/test.py
@@ -1,0 +1,125 @@
+
+import sys
+import os
+import os.path
+import grpc
+import tqdm
+from PIL import Image
+from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
+
+import interrogator
+
+
+import rpc_proto.services_pb2
+import rpc_proto.services_pb2_grpc
+
+
+
+
+def go(test_images):
+
+	maxMsgLength = 1024 * 1024 * 1024
+	channel = grpc.insecure_channel('localhost:50051',
+								options=[('grpc.max_message_length', maxMsgLength),
+										 ('grpc.max_send_message_length', maxMsgLength),
+										 ('grpc.max_receive_message_length', maxMsgLength)])
+
+	stub = rpc_proto.services_pb2_grpc.ImageInterrogatorStub(channel)
+
+	print(stub)
+	null_req = rpc_proto.services_pb2.InterrogatorListingRequest()
+	ret = stub.ListInterrogators(null_req)
+
+
+	networks = []
+	for name in ret.interrogator_names:
+
+		if "blip" in name.lower():
+			continue
+		if "GIT" in name:
+			continue
+
+		print(name)
+
+		networks.append(name)
+
+	for filename in tqdm.tqdm(test_images):
+
+
+		with open(filename, "rb") as fp:
+			im_bytes = fp.read()
+
+		interrogate_req = rpc_proto.services_pb2.InterrogationRequest(
+			params = [
+				rpc_proto.services_pb2.NetworkInterrogationParameters(
+					interrogator_network   = name,
+					interrogator_threshold = 0.1,
+				) for name in networks
+			],
+			interrogate_image      = im_bytes,
+
+			)
+
+		ret = stub.InterrogateImage(interrogate_req)
+
+		print("Result: ", ret)
+
+
+	# for in_name, intg in interrogator.INTERROGATOR_MAP.items():
+	# 	print(in_name)
+
+	# 	# if "danboor" in in_name.lower():
+	# 	# 	continue
+
+
+	# 	intg.start()
+
+	# 	for filename in tqdm.tqdm(test_images):
+	# 		im  = Image.open(filename)
+	# 		# print(im)
+
+	# 		results = intg.predict(im)
+	# 		# print(results)
+	# 		# print()
+
+
+	# 	intg.stop()
+
+	print("Ran all interrogators!")
+
+if __name__ == "__main__":
+
+	if len(sys.argv) < 2:
+		print("You need to specify a directory containing images")
+		sys.exit(-1)
+
+
+	fdir = sys.argv[1]
+
+	if not os.path.exists(fdir):
+		print("Passed directory ('%s') does not exist!" % (fdir, ))
+		sys.exit(-2)
+
+	if not os.path.isdir(fdir):
+
+		print("Passed directory ('%s') is not a directory!" % (fdir, ))
+		sys.exit(-2)
+
+	image_exts = [
+		".jpg",
+		".jpeg",
+		".png",
+		".bmp",
+		".webp",
+	]
+
+	images = []
+	for filename in os.listdir(fdir):
+		if any([filename.lower().endswith(fext) for fext in image_exts]):
+			images.append(os.path.join(fdir, filename))
+
+	print("Found %s images to test with." % (len(images), ))
+	go(images)
+
+
+


### PR DESCRIPTION
Ok, this splits the returns from each network into separate lists. 

The return value is now a `ImageTagResults` object that contains a list of `InterrogationResponse` objects, each of which has the name of the generating network, and a list of `TagEntry` objects.
