### PR TITLE
feat: adds support to .mp4 files

### DIFF
--- a/BooruDatasetTagManager/BooruDatasetTagManager.csproj
+++ b/BooruDatasetTagManager/BooruDatasetTagManager.csproj
@@ -52,6 +52,7 @@
     <Content Include="BDTM.ico" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FFMpegCore" Version="5.2.0" />
     <PackageReference Include="Google.Protobuf" Version="3.24.4" />
     <PackageReference Include="Grpc.Net.Client" Version="2.57.0" />
     <PackageReference Include="Grpc.Tools" Version="2.58.0">

--- a/BooruDatasetTagManager/DatasetManager.cs
+++ b/BooruDatasetTagManager/DatasetManager.cs
@@ -272,7 +272,7 @@ namespace BooruDatasetTagManager
 
         public bool LoadFromFolder(string folder)
         {
-            List<string> imagesExt = new List<string>() { ".jpg", ".png", ".bmp", ".jpeg", ".webp" };
+            List<string> imagesExt = new List<string>() { ".jpg", ".png", ".bmp", ".jpeg", ".webp", ".mp4" };
             string[] imgs = Directory.GetFiles(folder, "*.*", SearchOption.AllDirectories);
             if (imgs.Length == 0)
             {


### PR DESCRIPTION
I made this low effort change to be able to use Booru Tags on .mp4 videos, I'm not sure if this is good enough to be merged into the main repo, but at least, this can kick start the conversation.

With the advent of Video Diffusion models, like Hunyuan, Wan, Framepack, I can see the need to have better tagging and prompting systems.

I'm using this version for a little project of my own, so why not try to give it back to the community right