### PR TITLE
feat: adds support to .mp4 files

### DIFF
--- a/BooruDatasetTagManager/BooruDatasetTagManager.csproj
+++ b/BooruDatasetTagManager/BooruDatasetTagManager.csproj
@@ -52,6 +52,7 @@
     <Content Include="BDTM.ico" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FFMpegCore" Version="5.2.0" />
     <PackageReference Include="Google.Protobuf" Version="3.24.4" />
     <PackageReference Include="Grpc.Net.Client" Version="2.57.0" />
     <PackageReference Include="Grpc.Tools" Version="2.58.0">

--- a/BooruDatasetTagManager/DatasetManager.cs
+++ b/BooruDatasetTagManager/DatasetManager.cs
@@ -272,7 +272,7 @@ namespace BooruDatasetTagManager
 
         public bool LoadFromFolder(string folder)
         {
-            List<string> imagesExt = new List<string>() { ".jpg", ".png", ".bmp", ".jpeg", ".webp" };
+            List<string> imagesExt = new List<string>() { ".jpg", ".png", ".bmp", ".jpeg", ".webp", ".mp4" };
             string[] imgs = Directory.GetFiles(folder, "*.*", SearchOption.AllDirectories);
             if (imgs.Length == 0)
             {

--- a/BooruDatasetTagManager/Extensions.cs
+++ b/BooruDatasetTagManager/Extensions.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Data;
 using Newtonsoft.Json;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+using FFMpegCore;
 
 namespace BooruDatasetTagManager
 {
@@ -134,22 +135,38 @@ namespace BooruDatasetTagManager
         {
             bool isWebP = false;
             byte[] imageData = File.ReadAllBytes(imagePath);
+            var isMp4 = imagePath.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase);
             if (imageData.Length < 4)
                 return null;
             if (BitConverter.ToInt32(imageData, 0) == 1179011410 || BitConverter.ToInt32(imageData, 0) == 1346520407)
                 isWebP = true;
             try
             {
-                if (!isWebP)
-                {
-                    return Image.FromStream(new MemoryStream(imageData));
-                }
-                else
+                if (isWebP)
                 {
                     using (WebPWrapper.WebP wp = new WebPWrapper.WebP())
                     {
                         return wp.Load(imageData);
                     }
+                }
+                else if (isMp4) 
+                {    
+                    // Read the first frame from an MP4 video
+                    var jpg_path = imagePath.Replace(".mp4", ".jpg");
+                    FFMpegArguments.FromFileInput(imagePath).OutputToFile(jpg_path, true, options => options
+                            .WithVideoCodec("mjpeg")
+                            .WithFrameOutputCount(1)
+                            .Seek(TimeSpan.FromSeconds(0))
+                        ).ProcessSynchronously();
+                    using var fs = new FileStream(jpg_path, FileMode.Open, FileAccess.Read);
+                    var image = Image.FromStream(fs);
+                    fs.Close();
+                    File.Delete(jpg_path);
+                    return image;
+                }
+                else 
+                {
+                    return Image.FromStream(new MemoryStream(imageData));
                 }
             }
             catch (Exception)

--- a/BooruDatasetTagManager/Form1.cs
+++ b/BooruDatasetTagManager/Form1.cs
@@ -248,6 +248,10 @@ namespace BooruDatasetTagManager
 
         private void ShowPreview(string imgPath, bool separateWindow = false)
         {
+            if (imgPath.EndsWith(".mp4")) {
+                Process.Start(new ProcessStartInfo(imgPath) { UseShellExecute = true });
+                return;
+            }
             Image img = Program.DataManager.GetImageFromFileWithCache(imgPath);
             if (img == null)
                 return;


### PR DESCRIPTION
I made this low effort change to be able to use Booru Tags on .mp4 videos, I'm not sure if this is good enough to be merged into the main repo, but at least, this can kick start the conversation.

With the advent of Video Diffusion models, like Hunyuan, Wan, Framepack, I can see the need to have better tagging and prompting systems.

I'm using this version for a little project of my own, so why not try to give it back to the community right

Closed and opened a new PR because I forgot to delete the "temporary" image file" in the old one and would like to keep the change as 1 commit for organization